### PR TITLE
Fix fine resolution transformer not running during mp

### DIFF
--- a/src/RuntimeRes/ResolutionTransformer.cs
+++ b/src/RuntimeRes/ResolutionTransformer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using SyncroSim.Core;
 
@@ -15,7 +16,6 @@ namespace SyncroSim.STSim
         private Dictionary<int, List<int>> m_BaseToFineDictionary;
         private string m_MultiResFilename;
         private string m_STSimFilename;
-        private bool m_CanDoMultiResolution;
 
         public STSimTransformer STSimTransformer
         {
@@ -29,16 +29,9 @@ namespace SyncroSim.STSim
             }
         }
 
-        public override void Configure()
-        {
-            base.Configure();
-
-            this.m_CanDoMultiResolution = CanDoMultiResolution(this.ResultScenario);
-        }
-
         public override void Initialize()
         {
-            if(this.m_CanDoMultiResolution)
+            if (CanDoMultiResolution(this.ResultScenario))
             {
                 AuxillarySetup();
                 base.Initialize();


### PR DESCRIPTION
Apparently the `configure()` method only gets called at the start of the simulation, and does not get called again for each multiprocessing job. The `initialize()` method does get called for every job, so I just updated the if statement to check each time it's initialized whether the the simulation uses multiresolution.