### PR TITLE
Hide fine res criteria nodes when no active scenarios have multi resolution

### DIFF
--- a/src/Providers/STSimMapProvider.cs
+++ b/src/Providers/STSimMapProvider.cs
@@ -1428,29 +1428,20 @@ namespace SyncroSim.STSim
             return true;
         }
 
+        private static bool DatasheetHasRows(Scenario s, string datasheetName)
+        {
+            DataSheet ds = s.GetDataSheet(datasheetName);
+            return ds != null && ds.GetData().Rows.Count > 0;
+        }
+
+        private static bool ScenarioIsMultiRes(Scenario s)
+        {
+            return DatasheetHasRows(s, Strings.DATASHEET_TRG_NAME) && DatasheetHasRows(s, Strings.DATASHEET_SPICF_NAME);
+        }
+
         private static bool ShouldShowMultiResolutionCriteriaNodes(Project project, DataStore store)
         {
-            List<Scenario> resultScenarios = new List<Scenario>();
-
-            foreach (Scenario s in project.Results)
-            {
-                if(s.IsActive)
-                {
-                    resultScenarios.Add(s);
-                }
-            }
-
-            foreach (Scenario s in resultScenarios)
-            {
-                DataSheet initialConditionsFineSpatialDatasheet = s.GetDataSheet(Strings.DATASHEET_SPICF_NAME);
-
-                if(initialConditionsFineSpatialDatasheet != null && initialConditionsFineSpatialDatasheet.GetData().Rows.Count > 0)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return project?.Results?.Where(s => s.IsActive)?.Any(ScenarioIsMultiRes) == true;
         }
     }
 }

--- a/src/Providers/STSimMapProvider.cs
+++ b/src/Providers/STSimMapProvider.cs
@@ -40,7 +40,7 @@ namespace SyncroSim.STSim
 
         public override void RefreshCriteria(DataStore store, Layout layout, Project project)
         {
-            this.ShowMultiResolutionCriteriaNodes = ShouldShowMultiResolutionCriteriaNodes(project, store);
+            this.ShowMultiResolutionCriteriaNodes = ShouldShowMultiResolutionCriteriaNodes(project);
 
             DataView AttrGroupView = CreateMapAttributeGroupsView(project, store);     
 
@@ -1439,7 +1439,7 @@ namespace SyncroSim.STSim
             return DatasheetHasRows(s, Strings.DATASHEET_TRG_NAME) && DatasheetHasRows(s, Strings.DATASHEET_SPICF_NAME);
         }
 
-        private static bool ShouldShowMultiResolutionCriteriaNodes(Project project, DataStore store)
+        private static bool ShouldShowMultiResolutionCriteriaNodes(Project project)
         {
             return project?.Results?.Where(s => s.IsActive)?.Any(ScenarioIsMultiRes) == true;
         }

--- a/src/Providers/STSimMapProvider.cs
+++ b/src/Providers/STSimMapProvider.cs
@@ -1442,9 +1442,9 @@ namespace SyncroSim.STSim
 
             foreach (Scenario s in resultScenarios)
             {
-                DataSheet initialConditionsFineSpatrialDatasheet = s.GetDataSheet(Strings.DATASHEET_SPICF_NAME);
+                DataSheet initialConditionsFineSpatialDatasheet = s.GetDataSheet(Strings.DATASHEET_SPICF_NAME);
 
-                if(initialConditionsFineSpatrialDatasheet != null && initialConditionsFineSpatrialDatasheet.GetData().Rows.Count > 0)
+                if(initialConditionsFineSpatialDatasheet != null && initialConditionsFineSpatialDatasheet.GetData().Rows.Count > 0)
                 {
                     return true;
                 }


### PR DESCRIPTION
I found that only checking the Transition Group Resolution datasheet wasn't enough, so I also check the initial conditions spatial fine res datasheet for rows.