### PR TITLE
Throw error when distribution results in negative transition targets

### DIFF
--- a/src/Runtime/STSimTransformer.Distributions.cs
+++ b/src/Runtime/STSimTransformer.Distributions.cs
@@ -83,6 +83,13 @@ namespace SyncroSim.STSim
                     if (!t.IsDisabled)
                     {
                         t.Initialize(this.MinimumIteration, this.MinimumTimestep, this.m_DistributionProvider);
+
+                        if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
+                        {
+                            string colName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
+                            throw new Exception(String.Format(
+                                "The following distribution produces a negative transition target: {0}", colName));
+                        }
                     }
                 }
             }
@@ -269,6 +276,13 @@ namespace SyncroSim.STSim
                     if (!t.IsDisabled)
                     {
                         t.Sample(iteration, timestep, this.m_DistributionProvider, frequency);
+
+                        if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
+                        {
+                            string colName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
+                            throw new Exception(String.Format(
+                                "The following distribution produces a negative transition target: {0}", colName));
+                        }
                     }
                 }
             }
@@ -382,6 +396,19 @@ namespace SyncroSim.STSim
             catch (Exception ex)
             {
                 throw new ArgumentException("Transition Adjacency Multipliers" + " -> " + ex.Message);
+            }
+        }
+
+        private string GetProjectItemName(string dataSheetName, int? id)
+        {
+            if (!id.HasValue)
+            {
+                return "NULL";
+            }
+            else
+            {
+                DataSheet ds = this.Project.GetDataSheet(dataSheetName);
+                return ds.ValidationTable.GetDisplayName(id.Value);
             }
         }
     }

--- a/src/Runtime/STSimTransformer.Distributions.cs
+++ b/src/Runtime/STSimTransformer.Distributions.cs
@@ -91,9 +91,12 @@ namespace SyncroSim.STSim
                         {
                             t.CurrentValue = 0.0;
                             string distName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
-                            truncatedDists.Add(distName);
 
-                       }
+                            if (!truncatedDists.Contains(distName))
+                            {
+                                truncatedDists.Add(distName);
+                            }
+                        }
                     }
                 }
 
@@ -295,7 +298,11 @@ namespace SyncroSim.STSim
                         {
                             t.CurrentValue = 0.0;
                             string distName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
-                            truncatedDists.Add(distName);
+
+                            if (!truncatedDists.Contains(distName))
+                            {
+                                truncatedDists.Add(distName);
+                            }
                         }
                     }
                 }

--- a/src/Runtime/STSimTransformer.Distributions.cs
+++ b/src/Runtime/STSimTransformer.Distributions.cs
@@ -86,10 +86,12 @@ namespace SyncroSim.STSim
 
                         if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
                         {
-                            string distributionType = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
-                            throw new Exception(String.Format(
-                                "The following distribution produces a negative transition target: {0}", distributionType));
-                        }
+                            t.m_CurrentValue = 0.0;
+                            string distName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
+                            this.RecordStatus(StatusType.Warning, String.Format(
+                                "The following distribution produces a negative transition target that has been truncated to 0: {0}", 
+                                distName));
+                       }
                     }
                 }
             }
@@ -279,9 +281,11 @@ namespace SyncroSim.STSim
 
                         if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
                         {
-                            string distributionType = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
-                            throw new Exception(String.Format(
-                                "The following distribution produces a negative transition target: {0}", distributionType));
+                            t.m_CurrentValue = 0.0;
+                            string distName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
+                            this.RecordStatus(StatusType.Warning, String.Format(
+                                "The following distribution produces a negative transition target that has been truncated to 0: {0}",
+                                distName));
                         }
                     }
                 }

--- a/src/Runtime/STSimTransformer.Distributions.cs
+++ b/src/Runtime/STSimTransformer.Distributions.cs
@@ -86,9 +86,9 @@ namespace SyncroSim.STSim
 
                         if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
                         {
-                            string colName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
+                            string distributionType = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
                             throw new Exception(String.Format(
-                                "The following distribution produces a negative transition target: {0}", colName));
+                                "The following distribution produces a negative transition target: {0}", distributionType));
                         }
                     }
                 }
@@ -279,9 +279,9 @@ namespace SyncroSim.STSim
 
                         if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
                         {
-                            string colName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
+                            string distributionType = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
                             throw new Exception(String.Format(
-                                "The following distribution produces a negative transition target: {0}", colName));
+                                "The following distribution produces a negative transition target: {0}", distributionType));
                         }
                     }
                 }

--- a/src/Runtime/STSimTransformer.Distributions.cs
+++ b/src/Runtime/STSimTransformer.Distributions.cs
@@ -2,6 +2,7 @@
 // Copyright © 2007-2024 Apex Resource Management Solutions Ltd. (ApexRMS). All rights reserved.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using SyncroSim.Core;
 
@@ -78,6 +79,8 @@ namespace SyncroSim.STSim
         {
             try
             {
+                List<string> truncatedDists = new List<string>();
+
                 foreach (TransitionTarget t in this.m_TransitionTargets)
                 {
                     if (!t.IsDisabled)
@@ -86,13 +89,20 @@ namespace SyncroSim.STSim
 
                         if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
                         {
-                            t.m_CurrentValue = 0.0;
+                            t.CurrentValue = 0.0;
                             string distName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
-                            this.RecordStatus(StatusType.Warning, String.Format(
-                                "The following distribution produces a negative transition target that has been truncated to 0: {0}", 
-                                distName));
+                            truncatedDists.Add(distName);
+
                        }
                     }
+                }
+
+                if (truncatedDists.Count > 0)
+                {
+                    string truncatedDistsString = string.Join(", ", truncatedDists);
+                    this.RecordStatus(StatusType.Warning, String.Format(
+                        "The following distributions produce a negative transition target that has been truncated to 0: {0}",
+                        truncatedDistsString));
                 }
             }
             catch (Exception ex)
@@ -273,6 +283,8 @@ namespace SyncroSim.STSim
         {
             try
             {
+                List<string> truncatedDists = new List<string>();
+
                 foreach (TransitionTarget t in this.m_TransitionTargets)
                 {
                     if (!t.IsDisabled)
@@ -281,13 +293,19 @@ namespace SyncroSim.STSim
 
                         if (t.CurrentValue.HasValue && (t.CurrentValue < 0.0))
                         {
-                            t.m_CurrentValue = 0.0;
+                            t.CurrentValue = 0.0;
                             string distName = GetProjectItemName(Constants.DATASHEET_CORE_DISTRIBUTION_TYPE, t.DistributionTypeId);
-                            this.RecordStatus(StatusType.Warning, String.Format(
-                                "The following distribution produces a negative transition target that has been truncated to 0: {0}",
-                                distName));
+                            truncatedDists.Add(distName);
                         }
                     }
+                }
+
+                if (truncatedDists.Count > 0)
+                {
+                    string truncatedDistsString = string.Join(", ", truncatedDists);
+                    this.RecordStatus(StatusType.Warning, String.Format(
+                        "The following distributions produce a negative transition target that has been truncated to 0: {0}",
+                        truncatedDistsString));
                 }
             }
             catch (Exception ex)

--- a/src/Shared/Constants.cs
+++ b/src/Shared/Constants.cs
@@ -112,6 +112,9 @@ namespace SyncroSim.STSim
         public const string DATASHEET_OUTPUT_AVG_SPATIAL_STATE_ATTRIBUTE = "stsim_OutputSpatialAverageStateAttribute";
         public const string DATASHEET_OUTPUT_AVG_SPATIAL_TRANSITION_ATTRIBUTE = "stsim_OutputSpatialAverageTransitionAttribute";
 
+        //Core datasheets
+        public const string DATASHEET_CORE_DISTRIBUTION_TYPE = "core_DistributionType";
+
         //Spatial Output Datasheet Common Column Names
         public const string DATASHEET_OUTPUT_SPATIAL_FILENAME_COLUMN = "Filename";
 

--- a/src/Statistics/STSimDistributionBase.cs
+++ b/src/Statistics/STSimDistributionBase.cs
@@ -20,7 +20,7 @@ namespace SyncroSim.STSim
         private double? m_DistributionSD;
         private double? m_DistributionMin;
         private double? m_DistributionMax;
-        private double? m_CurrentValue;
+        internal double? m_CurrentValue;
         private bool m_IsDisabled;
 
         protected STSimDistributionBase

--- a/src/Statistics/STSimDistributionBase.cs
+++ b/src/Statistics/STSimDistributionBase.cs
@@ -20,7 +20,7 @@ namespace SyncroSim.STSim
         private double? m_DistributionSD;
         private double? m_DistributionMin;
         private double? m_DistributionMax;
-        internal double? m_CurrentValue;
+        private double? m_CurrentValue;
         private bool m_IsDisabled;
 
         protected STSimDistributionBase
@@ -151,6 +151,11 @@ namespace SyncroSim.STSim
             {
                 this.CheckDisabled();
                 return this.m_CurrentValue;
+            }
+
+            set
+            {
+                m_CurrentValue = value;
             }
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents negative transition-target values by clamping them to zero during initialization and resampling.
  * Adds consolidated warnings listing the distribution types when truncation occurs.

* **Chores**
  * Adds a standardized datasheet-name constant for core distribution types.
  * Internal compatibility and maintenance improvements for distribution handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->