### PR TITLE
Flow multipliers by stock duplicate value validation

### DIFF
--- a/src/Runtime/STSimTransformer.ExtProc.cs
+++ b/src/Runtime/STSimTransformer.ExtProc.cs
@@ -261,6 +261,7 @@ namespace SyncroSim.STSim
             {
                 this.m_TransitionTargets.Clear();
                 this.FillTransitionTargetCollection();
+                this.NormalizeForUserDistributions();
                 this.InitializeTransitionTargetDistributionValues();
                 this.InitializeTransitionTargetPrioritizations();
                 this.m_TransitionTargetMap = new TransitionTargetMap(this.ResultScenario, this.m_TransitionTargets);
@@ -269,6 +270,7 @@ namespace SyncroSim.STSim
             {
                 this.m_TransitionMultiplierValues.Clear();
                 this.FillTransitionMultiplierValueCollection();
+                this.NormalizeForUserDistributions();
                 this.InitializeTransitionMultiplierDistributionValues();
 
                 foreach (TransitionMultiplierType tmt in this.m_TransitionMultiplierTypes)
@@ -349,6 +351,7 @@ namespace SyncroSim.STSim
                 this.FillStateAttributeValueCollection();
                 this.m_StateAttributeTypeIds = null;
                 this.m_StateAttributeValueMap = null;
+                this.NormalizeForUserDistributions();
                 this.InitializeStateAttributes();
             }
             else if (dataSheet.Name == Strings.DATASHEET_TRANSITION_ATTRIBUTE_VALUE_NAME)
@@ -357,12 +360,14 @@ namespace SyncroSim.STSim
                 this.FillTransitionAttributeValueCollection();
                 this.m_TransitionAttributeValueMap = null;
                 this.m_TransitionAttributeTypeIds = null;
+                this.NormalizeForUserDistributions();
                 this.InitializeTransitionAttributes();
             }
             else if (dataSheet.Name == Strings.DATASHEET_TRANSITION_ATTRIBUTE_TARGET_NAME)
             {
                 this.m_TransitionAttributeTargets.Clear();
                 this.FillTransitionAttributeTargetCollection();
+                this.NormalizeForUserDistributions();
                 this.InitializeTransitionAttributeTargetDistributionValues();
                 this.InitializeTransitionAttributeTargetPrioritizations();
                 this.m_TransitionAttributeTargetMap = new TransitionAttributeTargetMap(this.ResultScenario, this.m_TransitionAttributeTargets);

--- a/src/RuntimeSF/FlowMultiplierByStockCollection.cs
+++ b/src/RuntimeSF/FlowMultiplierByStockCollection.cs
@@ -5,7 +5,7 @@ using System.Collections.ObjectModel;
 
 namespace SyncroSim.STSim
 {
-		internal class FlowMultiplierByStockCollection : Collection<FlowMultiplierByStock>
-		{
-		}
+    internal class FlowMultiplierByStockCollection : Collection<FlowMultiplierByStock>
+    {
+    }
 }

--- a/src/RuntimeSF/FlowMultiplierByStockMap.cs
+++ b/src/RuntimeSF/FlowMultiplierByStockMap.cs
@@ -113,7 +113,7 @@ namespace SyncroSim.STSim
                                 item.StateClassId, item.FlowGroupId, item.Iteration, item.Timestep, l);
                 }
 
-								if (l.ContainsKey(item.StockGroupId) && l.ContainsValue(item))
+								if (l.ContainsKey(item.StockValue))
 								{
 										ThrowDuplicateItemException();
 								}

--- a/src/RuntimeSF/StockFlowMapBase.cs
+++ b/src/RuntimeSF/StockFlowMapBase.cs
@@ -105,6 +105,11 @@ namespace SyncroSim.STSim
 			return this.GetProjectItemName(Strings.DATASHEET_STOCK_TYPE_NAME, id);
 		}
 
+		protected string GetStockGroupName(int? id)
+		{
+			return this.GetProjectItemName(Strings.DATASHEET_STOCK_GROUP_NAME, id);
+		}
+
 		protected string GetFlowGroupName(int? id)
 		{
 			return this.GetProjectItemName(Strings.DATASHEET_FLOW_GROUP_NAME, id);


### PR DESCRIPTION
Currently duplicate rows are not being handled. To test:

1. Load stsim library that uses stock flows
2. Add duplicate records in the flow multipliers by stock datasheet
3. With old SyncroSim, you will get the following non-descript error: `An entry with the same key already exists.`
4. With this version of SyncroSim, you should get an error telling you exactly which rows are duplicated



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Normalized user-defined distributions during data import for transition targets, multipliers, and state/transition attributes to improve consistency and reduce unexpected model behaviour.
  - Improved duplicate detection for stock-flow multipliers and converted internal errors into clearer, user-friendly messages that include Stock Group, Stratum (all levels), State Class, Flow Group, Iteration, and Timestep to aid troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->